### PR TITLE
Fix getting pubkey_id from depot user pubkey #91

### DIFF
--- a/share/goa/depot/mk/gpg.inc
+++ b/share/goa/depot/mk/gpg.inc
@@ -16,10 +16,9 @@ pubkey_path = $(firstword \
 
 # obtain key ID of 'depot/<user>/pubkey' to be used to select signing key
 pubkey_id = $(shell pubkey_file=$(call pubkey_path,$1); \
-                    $(GPG) --yes -o $$pubkey_file.dearmored --dearmor $$pubkey_file; \
-                    $(GPG) --with-colon --import-options show-only \
-                           --import $$pubkey_file.dearmored |\
-                    head -n 1 | cut -d: -f5; rm -f $$pubkey_file.dearmored)
+                    $(GPG) --dry-run --with-colon --import \
+                           --import-options import-show $$pubkey_file |\
+                    head -n 1 | cut -d: -f5)
 
 MISSING_PUBKEY_FILES := $(sort \
                            $(foreach A,$(ARCHIVES),\

--- a/share/goa/depot/mk/gpg.inc
+++ b/share/goa/depot/mk/gpg.inc
@@ -17,9 +17,9 @@ pubkey_path = $(firstword \
 # obtain key ID of 'depot/<user>/pubkey' to be used to select signing key
 pubkey_id = $(shell pubkey_file=$(call pubkey_path,$1); \
                     $(GPG) --yes -o $$pubkey_file.dearmored --dearmor $$pubkey_file; \
-                    $(GPG) --with-colon --no-default-keyring --list-public-keys \
-                           --keyring $$pubkey_file.dearmored |\
-                    head -n 2 | tail -n 1 | cut -d: -f5; rm -f $$pubkey_file.dearmored)
+                    $(GPG) --with-colon --import-options show-only \
+                           --import $$pubkey_file.dearmored |\
+                    head -n 1 | cut -d: -f5; rm -f $$pubkey_file.dearmored)
 
 MISSING_PUBKEY_FILES := $(sort \
                            $(foreach A,$(ARCHIVES),\


### PR DESCRIPTION
On systems with the option `use-keyboxd` is enabled in config, option `--no-keyring` in gpg command line doesn't work. The result of the pubkey_id function will be the first key in the keybox keyring instead of the id of pubkey from the depot user.