### PR TITLE
Nix package for goa

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,0 +1,44 @@
+{ pkgs,
+  lib ? pkgs.lib,
+  stdenv ? pkgs.stdenv,
+  toolchain-bin  ## provided by nixpkgs-genode
+}: 
+
+stdenv.mkDerivation rec {
+    name = "goa";
+    version = "2024-11-04";
+
+    src = ./.;
+
+    buildInputs = with pkgs; [
+      expect
+      
+      ## dependencies documented at https://github.com/genodelabs/goa/blob/master/bin/goa#L42
+      git gnumake wget findutils gnused diffutils gnutar libxml2.bin
+
+      ## dependencies for `goa help`
+      man less
+
+      ## https://github.com/genodelabs/goa/blob/master/share/goa/lib/actions/build.tcl#L152
+      toolchain-bin
+    ];
+
+    nativeBuildInputs = with pkgs; [
+      makeWrapper
+      gnused
+      autoPatchelfHook
+    ];
+
+    installPhase = ''
+        mkdir -p $out
+        cp -r ./* $out
+
+        wrapProgram $out/bin/goa --set PATH "${lib.makeBinPath buildInputs}:$PATH"
+
+        ## substitute hardcoded paths of genode-toolchain
+        sed -e 's@^set genode_tools_dir.*$@set genode_tools_dir "${toolchain-bin}/bin/"@' -i $out/share/goa/lib/backtrace
+        sed -e 's@set qt_tool_dir.*$@set qt_tool_dir "${toolchain-bin}/"@' -i $out/share/goa/lib/build/qmake.tcl  ## TODO test
+        sed -e 's@arm_v8a { set cross_dev_prefix.*$@arm_v8a { set cross_dev_prefix "${toolchain-bin}/bin/genode-aarch64-" }@' -i $out/share/goa/lib/command_line.tcl
+        sed -e 's@x86_64 *{ set cross_dev_prefix.*$@x86_64 { set cross_dev_prefix "${toolchain-bin}/bin/genode-x86-" }@' -i $out/share/goa/lib/command_line.tcl
+    '';
+}

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,64 @@
+{
+  "nodes": {
+    "flake-compat": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1696426674,
+        "narHash": "sha256-kvjfFW7WAETZlt09AgDn1MrtKzP7t90Vf7vypd3OL1U=",
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "rev": "0f9255e01c2351cc7d116c072cb317785dd33b33",
+        "type": "github"
+      },
+      "original": {
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
+    "genode-utils": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1713636587,
+        "narHash": "sha256-PaAHV6UAMw05oKV093OG11oOBSXYIMhyzA8h2bMO8gM=",
+        "owner": "zgzollers",
+        "repo": "nixpkgs-genode",
+        "rev": "0a85781db152deabc76e8c4ed87ef1b3759431b0",
+        "type": "github"
+      },
+      "original": {
+        "owner": "zgzollers",
+        "repo": "nixpkgs-genode",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1720535198,
+        "narHash": "sha256-zwVvxrdIzralnSbcpghA92tWu2DV2lwv89xZc8MTrbg=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "205fd4226592cc83fd4c0885a3e4c9c400efabb5",
+        "type": "github"
+      },
+      "original": {
+        "id": "nixpkgs",
+        "ref": "nixos-23.11",
+        "type": "indirect"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-compat": "flake-compat",
+        "genode-utils": "genode-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,53 @@
+{
+  description = ''
+    This flake provides `goa` with the required dependencies from [nixpkgs](https://nixos.org/).
+
+    The `goa`-executable can be used without installation:
+    ```sh
+    nix run github:johannesloetzsch/goa -- help
+    ```
+
+    The `defaultShell` opens an environment with `goa`, its dependencies and the `genode-toolchain`.
+    Usage:
+    ```sh
+    nix shell github:johannesloetzsch/goa
+    goa help
+    ```
+  '';
+
+  inputs = {
+    nixpkgs.url = "nixpkgs/nixos-23.11";
+
+    flake-compat = {
+      url = "github:edolstra/flake-compat";
+      flake = false;
+    };
+
+    genode-utils = {
+      url = "github:zgzollers/nixpkgs-genode";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+  };
+
+  outputs = { self, nixpkgs, flake-compat, genode-utils }:
+  let
+    inherit (genode-utils.packages.${system}) toolchain-bin;
+
+    system = "x86_64-linux";
+    pkgs = import nixpkgs { inherit system; };
+  in rec {
+    packages.${system} = rec {
+
+      ## The [Genode tool chain](https://genode.org/download/tool-chain)
+      ## provided by [nixpkgs-genode](https://github.com/zgzollers/nixpkgs-genode/blob/main/pkgs/toolchain-bin.nix)
+      inherit toolchain-bin;
+
+      goa = import ./default.nix { inherit pkgs toolchain-bin; };
+      default = goa;
+    };
+
+    defaultShell = pkgs.mkShell {
+      buildInputs = with packages.${system}; [ goa goa.buildInputs toolchain-bin ];
+    };
+  };
+}


### PR DESCRIPTION
Tested subcommands:

- [x] goa help
- [x] goa build
- [x] goa run
- [ ] goa import
- [ ] goa diff
- [ ] goa depot-dir
- [ ] goa build
- [ ] goa extract-abi-symbols
- [ ] goa run-dir
- [ ] goa backtrace
- [ ] goa export
- [ ] goa publish
- [ ] goa add-depot-user
- [ ] goa archive-versions

Tested examples:
- [ ] cmake_library
- [ ] cmake_step2
- [ ] hello_meson
- [ ] hello_posix
- [ ] index
- [ ] rust_debug
- [ ] cmake_sdl2
- [ ] external_rom
- [x] hello_make
- [ ] hello_nasm
- [ ] hello_rust
- [ ] qt5_core
- [ ] vfs

Other tasks:
- [ ] ci